### PR TITLE
Removing the link to the Structural Engine namespace

### DIFF
--- a/TAS_Adapter/CRUD/Read.cs
+++ b/TAS_Adapter/CRUD/Read.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using BH.oM.Base;
 using BHE = BH.oM.Environment;
-using BHS = BH.oM.Structural;
 using BH.oM.Environment.Elements;
 using BH.oM.Environment.Properties;
 using BH.oM.Environment.Interface;


### PR DESCRIPTION
### This PR has been archived 

Historic PR archive can be found [here](https://burohappold.sharepoint.com/sites/BHoM/01_Master%20File/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F01_Master%20File%2F999_BHoM_GitHub_History_Archive)
