### PR TITLE
Fix error when pulling building elements

### DIFF
--- a/TAS_Engine/Convert/Environment_oM/BuildingElement.cs
+++ b/TAS_Engine/Convert/Environment_oM/BuildingElement.cs
@@ -87,11 +87,19 @@ namespace BH.Engine.TAS
                 element.PanelCurve = panelCurve.First();
             else
             {
-                List<BHG.Polyline> polylines = Geometry.Compute.BooleanUnion(panelCurve, 1e-3);
-                if (polylines.Count == 1)
-                    element.PanelCurve = polylines.First();
-                else
-                    element.PanelCurve = Geometry.Create.PolyCurve(polylines);
+                try
+                {
+                    List<BHG.Polyline> polylines = Geometry.Compute.BooleanUnion(panelCurve, 1e-3);
+                    if (polylines.Count == 1)
+                        element.PanelCurve = polylines.First();
+                    else
+                        element.PanelCurve = Geometry.Create.PolyCurve(polylines);
+                }
+                catch(Exception e)
+                {
+                    BH.Engine.Reflection.Compute.RecordWarning("An error occurred in building element ID - " + element.BHoM_Guid + " - error was: " + e.ToString());
+                    element.PanelCurve = Geometry.Create.PolyCurve(panelCurve);
+                }
             }
 
             Dictionary<string, object> tasData = new Dictionary<string, object>();

--- a/TAS_Engine/Convert/Geometry_oM/Polyline.cs
+++ b/TAS_Engine/Convert/Geometry_oM/Polyline.cs
@@ -62,7 +62,8 @@ namespace BH.Engine.TAS
                 pIndex++;
             }
 
-            if(pnts.First().Distance(pnts.Last()) > BHG.Tolerance.Distance)
+            //if(pnts.First().Distance(pnts.Last()) > BHG.Tolerance.Distance)
+            if(pnts.First() != pnts.Last())
                 pnts.Add(pnts[0]); //Close the polyline
 
             return new BHG.Polyline { ControlPoints = pnts };


### PR DESCRIPTION
Fixes #134 

I say fixes... it resolves the error and allows the pull to work. The underlying cause of the error may still be occurring but the tool won't crash. More investigation may be required on it in the future.