### PR TITLE
Changes to align to FragmentSet; Replace ErrorLog with Reflection RecordError

### DIFF
--- a/TAS_T3DAdapter/TAST3DAdapter.cs
+++ b/TAS_T3DAdapter/TAST3DAdapter.cs
@@ -92,7 +92,7 @@ namespace BH.Adapter.TAS
             List<TAS3D.Zone> zones = new List<Zone>();
             int index = 1;
             TAS3D.Zone zone = null;
-            while((zone = t3dDocument.Building.GetZone(index)) != null)
+            while ((zone = t3dDocument.Building.GetZone(index)) != null)
             {
                 if (zone.isUsed == 0)
                     zones.Add(zone);
@@ -134,7 +134,7 @@ namespace BH.Adapter.TAS
             }
             catch (Exception e)
             {
-               BH.Engine.Reflection.Compute.RecordError(e.ToString());
+                BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 CloseT3DDocument();
                 return null;
@@ -171,7 +171,7 @@ namespace BH.Adapter.TAS
                 t3dDocument.Create();
 
             else
-               BH.Engine.Reflection.Compute.RecordError("The TBD file does not exist");
+                BH.Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return t3dDocument;
         }
 

--- a/TAS_T3DAdapter/TAST3DAdapter.cs
+++ b/TAS_T3DAdapter/TAST3DAdapter.cs
@@ -134,7 +134,7 @@ namespace BH.Adapter.TAS
             }
             catch (Exception e)
             {
-                ErrorLog.Add(e.ToString());
+               Engine.Reflection.Compute.RecordError(e.ToString());
                 BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 CloseT3DDocument();
                 return null;
@@ -171,7 +171,7 @@ namespace BH.Adapter.TAS
                 t3dDocument.Create();
 
             else
-                ErrorLog.Add("The TBD file does not exist");
+               Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return t3dDocument;
         }
 

--- a/TAS_T3DAdapter/TAST3DAdapter.cs
+++ b/TAS_T3DAdapter/TAST3DAdapter.cs
@@ -134,7 +134,7 @@ namespace BH.Adapter.TAS
             }
             catch (Exception e)
             {
-               Engine.Reflection.Compute.RecordError(e.ToString());
+               BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 CloseT3DDocument();
                 return null;
@@ -171,7 +171,7 @@ namespace BH.Adapter.TAS
                 t3dDocument.Create();
 
             else
-               Engine.Reflection.Compute.RecordError("The TBD file does not exist");
+               BH.Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return t3dDocument;
         }
 

--- a/TAS_TBDAdapter/CRUD/Read.cs
+++ b/TAS_TBDAdapter/CRUD/Read.cs
@@ -209,7 +209,7 @@ namespace BH.Adapter.TAS
                     {
                         Opening newOpening = new Opening();
                         newOpening.Edges = frame.ExternalEdges;
-                        newOpening.Fragments = new List<IBHoMFragment>(pane.Fragments);
+                        newOpening.Fragments = new FragmentSet(pane.Fragments);
 
                         string oldname = (newOpening.FindFragment<OriginContextFragment>(typeof(OriginContextFragment))).TypeName;
                         (newOpening.FindFragment<OriginContextFragment>(typeof(OriginContextFragment))).TypeName = oldname.RemoveStringPart(" -pane");

--- a/TAS_TBDAdapter/TASTBDAdapter.cs
+++ b/TAS_TBDAdapter/TASTBDAdapter.cs
@@ -101,7 +101,7 @@ namespace BH.Adapter.TAS
             }
             catch (Exception e)
             {
-               Engine.Reflection.Compute.RecordError(e.ToString());
+                BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 CloseTbdDocument(false);
                 return null;
@@ -133,7 +133,7 @@ namespace BH.Adapter.TAS
                 tbdDocument.create(tbdFilePath); //TODO: what if an existing file has the same name? 
 
             else
-               Engine.Reflection.Compute.RecordError("The TBD file does not exist");
+                BH.Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return tbdDocument;
         }
 
@@ -147,7 +147,7 @@ namespace BH.Adapter.TAS
                 tbdDocument.create(tbdFilePath); //TODO: what if an existing file has the same name? 
 
             else
-               Engine.Reflection.Compute.RecordError("The TBD file does not exist");
+                BH.Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return tbdDocument;
         }
 

--- a/TAS_TBDAdapter/TASTBDAdapter.cs
+++ b/TAS_TBDAdapter/TASTBDAdapter.cs
@@ -101,7 +101,7 @@ namespace BH.Adapter.TAS
             }
             catch (Exception e)
             {
-                ErrorLog.Add(e.ToString());
+               Engine.Reflection.Compute.RecordError(e.ToString());
                 BH.Engine.Reflection.Compute.RecordError(e.ToString());
                 CloseTbdDocument(false);
                 return null;
@@ -133,7 +133,7 @@ namespace BH.Adapter.TAS
                 tbdDocument.create(tbdFilePath); //TODO: what if an existing file has the same name? 
 
             else
-                ErrorLog.Add("The TBD file does not exist");
+               Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return tbdDocument;
         }
 
@@ -147,7 +147,7 @@ namespace BH.Adapter.TAS
                 tbdDocument.create(tbdFilePath); //TODO: what if an existing file has the same name? 
 
             else
-                ErrorLog.Add("The TBD file does not exist");
+               Engine.Reflection.Compute.RecordError("The TBD file does not exist");
             return tbdDocument;
         }
 

--- a/TAS_TSDAdapter/TASTSDAdapter.cs
+++ b/TAS_TSDAdapter/TASTSDAdapter.cs
@@ -200,7 +200,7 @@ namespace BH.Adapter.TAS
                 tsdDocument.create(tsdFilePath); //What if an existing file has the same name?
 
             else
-               Engine.Reflection.Compute.RecordError("The TSD file does not exist");
+               BH.Engine.Reflection.Compute.RecordError("The TSD file does not exist");
             return tsdDocument;
         }
         //TODO: Do we need both of these?
@@ -215,7 +215,7 @@ namespace BH.Adapter.TAS
                 tsdDocument.create(tsdFilePath); //What if an existing file has the same name?
 
             else
-               Engine.Reflection.Compute.RecordError("The TSD file does not exist");
+               BH.Engine.Reflection.Compute.RecordError("The TSD file does not exist");
             return tsdDocument;
         }
 

--- a/TAS_TSDAdapter/TASTSDAdapter.cs
+++ b/TAS_TSDAdapter/TASTSDAdapter.cs
@@ -200,7 +200,7 @@ namespace BH.Adapter.TAS
                 tsdDocument.create(tsdFilePath); //What if an existing file has the same name?
 
             else
-                ErrorLog.Add("The TSD file does not exist");
+               Engine.Reflection.Compute.RecordError("The TSD file does not exist");
             return tsdDocument;
         }
         //TODO: Do we need both of these?
@@ -215,7 +215,7 @@ namespace BH.Adapter.TAS
                 tsdDocument.create(tsdFilePath); //What if an existing file has the same name?
 
             else
-                ErrorLog.Add("The TSD file does not exist");
+               Engine.Reflection.Compute.RecordError("The TSD file does not exist");
             return tsdDocument;
         }
 

--- a/TAS_TSDAdapter/TASTSDAdapter.cs
+++ b/TAS_TSDAdapter/TASTSDAdapter.cs
@@ -58,13 +58,13 @@ namespace BH.Adapter.TAS
 
         private bool CheckInputCombinations()
         {
-            if(tsdFilePath == "")
+            if (tsdFilePath == "")
             {
                 BH.Engine.Reflection.Compute.RecordError("Please provide a valid TSD input file path");
                 return false;
             }
 
-            if(tsdResultType == TSDResultType.Undefined)
+            if (tsdResultType == TSDResultType.Undefined)
             {
                 BH.Engine.Reflection.Compute.RecordError("Result output cannot be undefined");
                 return false;
@@ -85,25 +85,25 @@ namespace BH.Adapter.TAS
                 return false;
             }
 
-            if((tsdResultType == TSDResultType.CoolingDesignDay || tsdResultType == TSDResultType.HeatingDesignDay) && (SimulationResultType == SimulationResultType.BuildingResult || SimulationResultType == SimulationResultType.BuildingElementResult))
+            if ((tsdResultType == TSDResultType.CoolingDesignDay || tsdResultType == TSDResultType.HeatingDesignDay) && (SimulationResultType == SimulationResultType.BuildingResult || SimulationResultType == SimulationResultType.BuildingElementResult))
             {
                 BH.Engine.Reflection.Compute.RecordError("Heating and Cooling Design Day results are only available on Space Result Types");
                 return false;
             }
 
-            if(ProfileResultUnits == ProfileResultUnit.Daily && (Day < 1 || Day > 365))
+            if (ProfileResultUnits == ProfileResultUnit.Daily && (Day < 1 || Day > 365))
             {
                 BH.Engine.Reflection.Compute.RecordError("Please select a day between 1 and 365 inclusive for Daily Results");
                 return false;
             }
 
-            if(ProfileResultUnits == ProfileResultUnit.Hourly && (Hour < 1 || Hour > 24))
+            if (ProfileResultUnits == ProfileResultUnit.Hourly && (Hour < 1 || Hour > 24))
             {
                 BH.Engine.Reflection.Compute.RecordError("Please select an hour between 1 and 24 inclusive for Hourly Results");
                 return false;
             }
 
-            if(ProfileResultUnits == ProfileResultUnit.Yearly && (Hour != -1 || Day != -1))
+            if (ProfileResultUnits == ProfileResultUnit.Yearly && (Hour != -1 || Day != -1))
             {
                 BH.Engine.Reflection.Compute.RecordWarning("Day and Hour inputs are not used when pulling Yearly Results");
             }
@@ -139,7 +139,7 @@ namespace BH.Adapter.TAS
                 List<IBHoMObject> returnObjs = new List<IBHoMObject>();
 
                 FilterRequest aFilterQuery = request as FilterRequest;
-                GetTsdDocumentReadOnly (); //Open the TSD Document for pulling data from
+                GetTsdDocumentReadOnly(); //Open the TSD Document for pulling data from
 
                 if (tsdDocument != null)
                 {
@@ -176,7 +176,7 @@ namespace BH.Adapter.TAS
         /**** Private Fields                            ****/
         /***************************************************/
 
-        private TSD.TSDDocument tsdDocument=null;
+        private TSD.TSDDocument tsdDocument = null;
         private string tsdFilePath = null;
         private TSDResultType tsdResultType = TSDResultType.Undefined;
         private SimulationResultType SimulationResultType = SimulationResultType.Undefined;
@@ -200,7 +200,7 @@ namespace BH.Adapter.TAS
                 tsdDocument.create(tsdFilePath); //What if an existing file has the same name?
 
             else
-               BH.Engine.Reflection.Compute.RecordError("The TSD file does not exist");
+                BH.Engine.Reflection.Compute.RecordError("The TSD file does not exist");
             return tsdDocument;
         }
         //TODO: Do we need both of these?
@@ -215,19 +215,19 @@ namespace BH.Adapter.TAS
                 tsdDocument.create(tsdFilePath); //What if an existing file has the same name?
 
             else
-               BH.Engine.Reflection.Compute.RecordError("The TSD file does not exist");
+                BH.Engine.Reflection.Compute.RecordError("The TSD file does not exist");
             return tsdDocument;
         }
 
         //Close and save the TSD Document
-        private void CloseTsdDocument(bool save=true)
+        private void CloseTsdDocument(bool save = true)
         {
-            if (tsdDocument!=null)
+            if (tsdDocument != null)
             {
                 if (save == true)
                     tsdDocument.save();
                 tsdDocument.close();
-                if(tsdDocument!=null)
+                if (tsdDocument != null)
                 {
                     ClearCOMObject(tsdDocument);
                     tsdDocument = null;

--- a/TAS_TSDAdapter/TASTSDAdapter.cs
+++ b/TAS_TSDAdapter/TASTSDAdapter.cs
@@ -163,7 +163,6 @@ namespace BH.Adapter.TAS
                 BH.Engine.Reflection.Compute.RecordError(ex.ToString());
                 CloseTsdDocument();
                 return null;
-
             }
             finally
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
1. BHoM/BHoM#574 (main BHoM.oM change)
2. BHoM/BHoM_Engine#1248 (aligns BHoM_Engine to 1.)

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #217 
Closes #218

 <!-- Add short description of what has been fixed -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Changes to align to FragmentSet change.
- Replaced all `ErrorLog.Add` with `Engine.Reflection.Compute.RecordError`.

## Important note
To be merged with https://github.com/BHoM/BHoM_Engine/pull/1248